### PR TITLE
 Network Migration scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ build/
 .DS_Store/
 
 .vscode/
+
+# output script files
+*.csv

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "author": "LeapDAO",
   "license": "MPL-2.0",
   "dependencies": {
+    "csv-parser": "^2.2.0",
+    "csv-writer": "^1.2.0",
     "ethereumjs-util": "^6.1.0",
     "ethers": "^4.0.27",
-    "leap-core": "^0.28.1",
+    "jsbi": "^2.0.5",
+    "leap-core": "^0.28.3",
     "truffle-hdwallet-provider": "^1.0.6",
     "web3": "1.0.0-beta.34"
   }

--- a/scripts/migration/compareBalances.js
+++ b/scripts/migration/compareBalances.js
@@ -1,0 +1,33 @@
+const JSBI = require('jsbi');
+const ethers = require('ethers');
+const fs = require('fs');
+const csv = require('csv-parser');
+const { getBalance } = require('./helpers');
+
+const nodeUrl = "http://node1.testnet.leapdao.org:8645";
+const rpc = new ethers.providers.JsonRpcProvider(nodeUrl);
+const snapshot = './snapshot.csv';
+
+async function run() {
+    const balances = [];
+
+    fs.createReadStream(snapshot)  
+    .pipe(csv())
+    .on('data', (row) => {
+        balances.push(row);
+    })
+    .on('end', async () => {
+        let balance; 
+        for(let i = 0; i < balances.length; i++) {
+            console.log('Checking ballance of', balances[i].Address);
+            balance = await getBalance(balances[i].Address, rpc);
+            if (String(balance) === balances[i].Balance) {
+                console.log('   OK');
+            } else {
+                console.log('   Mismatch! Expected:', balances[i].Balance, 'actual: ', String(balance));
+            }
+        }        
+    });  
+}
+
+run();

--- a/scripts/migration/compareBalances.js
+++ b/scripts/migration/compareBalances.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const csv = require('csv-parser');
 const { getBalance } = require('./helpers');
 
-const nodeUrl = "http://node1.testnet.leapdao.org:8645";
+const nodeUrl = process.argv[2] ? process.argv[2] : "https://testnet-node.leapdao.org";
 const rpc = new ethers.providers.JsonRpcProvider(nodeUrl);
 const snapshot = './snapshot.csv';
 

--- a/scripts/migration/dispenseTokens.js
+++ b/scripts/migration/dispenseTokens.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const csv = require('csv-parser');
 const { sendFunds, getBalance } = require ('./helpers');
 
-const nodeUrl = "http://node1.testnet.leapdao.org:8645";
+const nodeUrl = process.argv[2] ? process.argv[2] : "https://testnet-node.leapdao.org";
 const rpc = new ethers.providers.JsonRpcProvider(nodeUrl);
 const dispenser = { 
     address: 'PUT DISPENSER ADDRESS HERE',

--- a/scripts/migration/dispenseTokens.js
+++ b/scripts/migration/dispenseTokens.js
@@ -24,6 +24,11 @@ async function run() {
     .on('end', async () => {
         for(let i = 0; i < balances.length; i++) {
             console.log('Dispensng', balances[i].Balance, 'LEAP to', balances[i].Address);
+            balance = await getBalance(balances[i].Address, rpc);
+            if (String(balance) !== '0') {
+                console.log('   Address already funded(', String(balance), '). Skipping.');
+                continue;
+            } 
             await sendFunds(dispenser, balances[i].Address, balances[i].Balance, rpc);
             balance = await getBalance(balances[i].Address, rpc);
             if (String(balance) === balances[i].Balance) {

--- a/scripts/migration/dispenseTokens.js
+++ b/scripts/migration/dispenseTokens.js
@@ -1,0 +1,38 @@
+const JSBI = require('jsbi');
+const ethers = require('ethers');
+const fs = require('fs');
+const csv = require('csv-parser');
+const { sendFunds, getBalance } = require ('./helpers');
+
+const nodeUrl = "http://node1.testnet.leapdao.org:8645";
+const rpc = new ethers.providers.JsonRpcProvider(nodeUrl);
+const dispenser = { 
+    address: 'PUT DISPENSER ADDRESS HERE',
+    priv: '!!!NEVER COMMIT WITH MAINNET PRIVATE KEY HERE!!!' //!!!NEVER COMMIT WITH MAINNET PRIVATE KEY HERE!!!
+}
+const snapshot = './snapshot.csv';
+
+async function run() {
+    const balances = [];
+    let balance;
+
+    fs.createReadStream(snapshot)  
+    .pipe(csv())
+    .on('data', (row) => {
+        balances.push(row);
+    })
+    .on('end', async () => {
+        for(let i = 0; i < balances.length; i++) {
+            console.log('Dispensng', balances[i].Balance, 'LEAP to', balances[i].Address);
+            await sendFunds(dispenser, balances[i].Address, balances[i].Balance, rpc);
+            balance = await getBalance(balances[i].Address, rpc);
+            if (String(balance) === balances[i].Balance) {
+                console.log('   Done');
+            } else {
+                console.log('   Failed! Expected balance:', balances[i].Balance, 'actual: ', String(balance));
+            }
+        }        
+    });
+}
+
+run();

--- a/scripts/migration/getSnapshot.js
+++ b/scripts/migration/getSnapshot.js
@@ -3,7 +3,7 @@ const ethers = require('ethers');
 const createCsvWriter = require('csv-writer').createArrayCsvWriter;
 const { getBalancesAll } = require('./helpers');
 
-const nodeUrl = "http://node1.testnet.leapdao.org:8645";
+const nodeUrl = process.argv[2] ? process.argv[2] : "https://testnet-node.leapdao.org";
 const rpc = new ethers.providers.JsonRpcProvider(nodeUrl);
 const snapshot = './snapshot.csv';
 

--- a/scripts/migration/getSnapshot.js
+++ b/scripts/migration/getSnapshot.js
@@ -1,0 +1,30 @@
+const JSBI = require('jsbi');
+const ethers = require('ethers');
+const createCsvWriter = require('csv-writer').createArrayCsvWriter;
+const { getBalancesAll } = require('./helpers');
+
+const nodeUrl = "http://node1.testnet.leapdao.org:8645";
+const rpc = new ethers.providers.JsonRpcProvider(nodeUrl);
+const snapshot = './snapshot.csv';
+
+async function run() {
+    const unspentsAll = await getBalancesAll(rpc);
+    console.log(unspentsAll);
+    
+    const totalValue = [...unspentsAll].reduce((sum, balance) => {
+        return JSBI.add(sum, JSBI.BigInt(balance[1])) }, JSBI.BigInt(0));
+
+    console.log("Total value of all addresses: ", String(totalValue));
+
+    console.log('Writing balances data to CSV file');
+    const csvWriter = createCsvWriter({  
+        path: snapshot,
+        header: ['Address', 'Balance']
+    });
+
+    csvWriter  
+        .writeRecords([...unspentsAll])
+        .then(() => console.log('The CSV file was written successfully'));
+}
+
+run();

--- a/scripts/migration/helpers.js
+++ b/scripts/migration/helpers.js
@@ -1,0 +1,51 @@
+const JSBI = require('jsbi');
+const { Tx, helpers, Output, Outpoint } = require('leap-core');
+
+async function getBalance(address, rpc) {
+    const response = await rpc.send('plasma_unspent', [address]);
+    const balance = response.reduce((sum, unspent) => { 
+        return (unspent.output.color === 0) ? JSBI.add(sum, JSBI.BigInt(unspent.output.value)) : sum}, JSBI.BigInt(0));
+
+    return balance;
+}
+
+async function getBalancesAll(rpc) {
+    const response = await rpc.send('plasma_unspent', []);
+    let balances = new Map();
+    let value;
+    let address;
+    response.forEach(unspent => {
+        if (unspent.output.color === 0) {
+            address = unspent.output.address;
+            value = JSBI.BigInt(unspent.output.value);
+            value = balances.get(address) ? JSBI.add(JSBI.BigInt(balances.get(address)), value) : value;
+            balances.set(address, String(value));
+        }        
+    });
+
+    return balances;
+}
+
+async function sendFunds(from, to, amount, rpc) {
+    const utxos = (await rpc.send("plasma_unspent", [from.address]))
+    .map(u => ({
+      output: u.output,
+      outpoint: Outpoint.fromRaw(u.outpoint),
+    }));
+
+    if (utxos.length === 0) {
+        throw new Error("No tokens left in the dispenser wallet");
+    }
+
+    const inputs = helpers.calcInputs(utxos, from.address, amount, 0);
+
+    let outputs = helpers.calcOutputs(utxos, inputs, from.address, to, amount, 0);
+
+    const tx = Tx.transfer(inputs, outputs).signAll(from.priv);
+
+    // eslint-disable-next-line no-console
+    const txHash = await rpc.send("eth_sendRawTransaction", [tx.hex()]);
+    console.log('txHash:', txHash);
+}
+
+module.exports = { getBalance, getBalancesAll, sendFunds }

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,7 +283,7 @@ buffer-alloc-unsafe@^1.1.0:
   resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
   integrity sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
 
-buffer-alloc@^1.2.0:
+buffer-alloc@^1.1.0, buffer-alloc@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
   integrity sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
@@ -300,6 +300,11 @@ buffer-fill@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
   integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
+
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 buffer-to-arraybuffer@^0.0.5:
   version "0.0.5"
@@ -430,6 +435,17 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-spawn@^6.0.0:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 crypto-browserify@3.12.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
@@ -446,6 +462,24 @@ crypto-browserify@3.12.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+csv-parser@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/csv-parser/-/csv-parser-2.2.0.tgz#241dc4d02854f1b05965895219988338240d833a"
+  integrity sha512-d2USCnRP5fSMHEPfVdzIxlk7+zpFlffak5Ad4Ndzm3Nw1rmxBxezpyL4A3FD1g4R+W/cx2TEeKnGdTz49BJyRg==
+  dependencies:
+    buffer-alloc "^1.1.0"
+    buffer-from "^1.0.0"
+    execa "^1.0.0"
+    generate-function "^1.0.1"
+    generate-object-property "^1.0.0"
+    minimist "^1.2.0"
+    ndjson "^1.4.0"
+
+csv-writer@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/csv-writer/-/csv-writer-1.2.0.tgz#b81a818e297e05308e9b1fc2f8c9342e0206cfea"
+  integrity sha512-ZU7eZ26y7oIOXwFHhTNnT/tF6RXMdQnuTGofzNTe1cvXacZm3Ixd7Oa9mOp2f1t39Ezfzg0h5tqfOjXM180BOg==
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -625,7 +659,7 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-end-of-stream@^1.0.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
@@ -755,6 +789,19 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
+
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 express@^4.14.0:
   version "4.16.4"
@@ -931,6 +978,18 @@ function-bind@^1.0.2, function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+generate-function@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-1.1.0.tgz#54c21b080192b16d9877779c5bb81666e772365f"
+  integrity sha1-VMIbCAGSsW2Yd3ecW7gWZudyNl8=
+
+generate-object-property@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
+  integrity sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=
+  dependencies:
+    is-property "^1.0.0"
+
 get-stream@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
@@ -943,6 +1002,13 @@ get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
+
+get-stream@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -1160,6 +1226,11 @@ is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
+is-property@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+  integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
+
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
@@ -1193,6 +1264,11 @@ isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -1244,7 +1320,7 @@ json-schema@0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -1284,7 +1360,7 @@ keccakjs@^0.2.1:
     browserify-sha3 "^0.0.4"
     sha3 "^1.2.2"
 
-leap-core@^0.28.1:
+leap-core@^0.28.3:
   version "0.28.3"
   resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.28.3.tgz#6dbc8344eed119fb067b2a53a4a9aae37b861abe"
   integrity sha512-9Rwo/5Uuo7sOCwmNTq1aksmUMjAkLg+Q/Im0NLDXGN/M53uXfJlAjJS2Xs/fL21iw4pK4wZKI4zpYy72xCdhAg==
@@ -1389,6 +1465,11 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
+minimist@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+
 mkdirp-promise@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz#e9b8f68e552c68a9c1713b84883f7a1dd039b8a1"
@@ -1442,10 +1523,32 @@ nano-json-stream-parser@^0.1.2:
   resolved "https://registry.yarnpkg.com/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz#0cc8f6d0e2b622b479c40d499c46d64b755c6f5f"
   integrity sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=
 
+ndjson@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/ndjson/-/ndjson-1.5.0.tgz#ae603b36b134bcec347b452422b0bf98d5832ec8"
+  integrity sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=
+  dependencies:
+    json-stringify-safe "^5.0.1"
+    minimist "^1.2.0"
+    split2 "^2.1.0"
+    through2 "^2.0.3"
+
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
   integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
+
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
+  dependencies:
+    path-key "^2.0.0"
 
 number-to-bn@1.7.0:
   version "1.7.0"
@@ -1538,6 +1641,11 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
+path-key@^2.0.0, path-key@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
@@ -1626,6 +1734,14 @@ public-encrypt@^4.0.0:
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
 
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -1685,7 +1801,7 @@ raw-body@2.3.3:
     iconv-lite "0.4.23"
     unpipe "1.0.0"
 
-readable-stream@^2.3.0, readable-stream@^2.3.5:
+readable-stream@^2.3.0, readable-stream@^2.3.5, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -1815,6 +1931,11 @@ seek-bzip@^1.0.5:
   dependencies:
     commander "~2.8.1"
 
+semver@^5.5.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+
 send@0.16.2:
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/send/-/send-0.16.2.tgz#6ecca1e0f8c156d141597559848df64730a6bbc1"
@@ -1885,6 +2006,23 @@ sha3@^1.2.2:
   dependencies:
     nan "2.10.0"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+signal-exit@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+  integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
 simple-concat@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
@@ -1898,6 +2036,13 @@ simple-get@^2.7.0:
     decompress-response "^3.3.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
+
+split2@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
+  integrity sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==
+  dependencies:
+    through2 "^2.0.2"
 
 sshpk@^1.7.0:
   version "1.16.1"
@@ -1951,6 +2096,11 @@ strip-dirs@^2.0.0:
   integrity sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==
   dependencies:
     is-natural-number "^4.0.1"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+  integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
 strip-hex-prefix@1.0.0:
   version "1.0.0"
@@ -2024,6 +2174,14 @@ thenify-all@^1.0.0, thenify-all@^1.6.0:
   integrity sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
   dependencies:
     any-promise "^1.0.0"
+
+through2@^2.0.2, through2@^2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
+  dependencies:
+    readable-stream "~2.3.6"
+    xtend "~4.0.1"
 
 through@^2.3.8:
   version "2.3.8"
@@ -2404,6 +2562,13 @@ websocket@^1.0.28:
     typedarray-to-buffer "^3.1.2"
     yaeti "^0.0.6"
 
+which@^1.2.9:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -2458,7 +2623,7 @@ xmlhttprequest@1.8.0:
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
   integrity sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=
 
-xtend@^4.0.0:
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
   integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=


### PR DESCRIPTION
Fixes #8 
Scripts to move balances to new network in support of network migration
 1. `getSnapsho` - creates CSV file with all the balances
 1. `dispenseTokens` - reads CSV file and sends funds from "dispenser" address accordingly
 1. `compareBalances` - compares actual balances on the network against CSV file