### PR TITLE
Improvements for migration scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ethers": "^4.0.27",
     "jsbi": "^2.0.5",
     "leap-core": "0.30.1",
+    "lodash.chunk": "^4.2.0",
     "truffle-hdwallet-provider": "^1.0.6",
     "web3": "1.0.0-beta.37"
   }

--- a/scripts/migration/compareBalances.js
+++ b/scripts/migration/compareBalances.js
@@ -1,20 +1,21 @@
 const ethers = require('ethers');
+const chunk = require('lodash.chunk');
 const { checkBalance, readSnapshot } = require('./helpers');
 
-const nodeUrl = process.argv[2]
-  ? process.argv[2]
-  : 'https://testnet-node.leapdao.org';
-
-const rpc = new ethers.providers.JsonRpcProvider(nodeUrl);
+const rpc = new ethers.providers.JsonRpcProvider(process.env.NODE_URL);
 const snapshot = './snapshot.csv';
 
 async function run() {
   const balances = await readSnapshot(snapshot);
-
-  const results = await Promise.all(
-    balances.map(record => checkBalance(record.Address, record.Balance, rpc))
-  );
-
+  
+  let results = [];
+  const chunks = chunk(balances, 20);
+  for (let i = 0; i < chunks.length; i++) {
+    results = results.concat(await Promise.all(chunks[i].map(
+        record => checkBalance(record.Address, record.Balance, rpc)
+    )));
+  }
+  
   results.map(r =>
     console.log(`${r.addr} ${r.result ? 'OK' : 'FAIL'}, Balance: ${r.balance}`)
   );

--- a/scripts/migration/compareBalances.js
+++ b/scripts/migration/compareBalances.js
@@ -1,39 +1,54 @@
-const ethers = require("ethers");
-const fs = require("fs");
-const csv = require("csv-parser");
-const { getBalance } = require("./helpers");
+const ethers = require('ethers');
+const fs = require('fs');
+const csv = require('csv-parser');
+const { getBalance } = require('./helpers');
 
 const nodeUrl = process.argv[2]
   ? process.argv[2]
-  : "https://testnet-node.leapdao.org";
+  : 'https://testnet-node.leapdao.org';
 
 const rpc = new ethers.providers.JsonRpcProvider(nodeUrl);
-const snapshot = "./snapshot.csv";
+const snapshot = './snapshot.csv';
+
+const readSnapshot = () =>
+  new Promise(resolve => {
+    const balances = [];
+    fs.createReadStream(snapshot)
+      .pipe(csv())
+      .on('data', row => {
+        balances.push(row);
+      })
+      .on('end', () => resolve(balances));
+  });
 
 async function run() {
-  const balances = [];
+  const balances = await readSnapshot();
 
-  fs.createReadStream(snapshot)
-    .pipe(csv())
-    .on("data", row => {
-      balances.push(row);
+  let match = true;
+
+  await Promise.all(
+    balances.map(async record => {
+      return getBalance(record.Address, rpc)
+        .then(balance => {
+          if (String(balance) === record.Balance) {
+            console.log(record.Address, 'OK');
+          } else {
+            match = false;
+            console.log(
+              record.Address,
+              'FAIL',
+              `Expected: ${record.Balance}, Actual: ${balance}`,
+            );
+          }
+        })
+        .catch(e => {
+          match = false;
+          console.log(record.Address, 'FAIL', e);
+        });
     })
-    .on("end", async () => {
-      balances.forEach(async record => {
-        const balance = await getBalance(record.Address, rpc);
-        if (String(balance) === record.Balance) {
-          console.log(record.Address, "   OK");
-        } else {
-          console.log(
-            record.Address,
-            "   Mismatch! Expected:",
-            record.Balance,
-            "actual: ",
-            String(balance)
-          );
-        }
-      });
-    });
+  );
+
+  console.log('Balance check:', match ? 'PASS' : 'FAIL (see above)');
 }
 
 run();

--- a/scripts/migration/compareBalances.js
+++ b/scripts/migration/compareBalances.js
@@ -1,30 +1,39 @@
-const ethers = require('ethers');
-const fs = require('fs');
-const csv = require('csv-parser');
-const { getBalance } = require('./helpers');
+const ethers = require("ethers");
+const fs = require("fs");
+const csv = require("csv-parser");
+const { getBalance } = require("./helpers");
 
-const nodeUrl = process.argv[2] ? process.argv[2] : "https://testnet-node.leapdao.org";
+const nodeUrl = process.argv[2]
+  ? process.argv[2]
+  : "https://testnet-node.leapdao.org";
+
 const rpc = new ethers.providers.JsonRpcProvider(nodeUrl);
-const snapshot = './snapshot.csv';
+const snapshot = "./snapshot.csv";
 
 async function run() {
-    const balances = [];
+  const balances = [];
 
-    fs.createReadStream(snapshot)  
+  fs.createReadStream(snapshot)
     .pipe(csv())
-    .on('data', (row) => {
-        balances.push(row);
+    .on("data", row => {
+      balances.push(row);
     })
-    .on('end', async () => {
-        balances.forEach(async (record) => {
-            const balance = await getBalance(record.Address, rpc);
-            if (String(balance) === record.Balance) {
-                console.log(record.Address, '   OK');
-            } else {
-                console.log(record.Address, '   Mismatch! Expected:', record.Balance, 'actual: ', String(balance));
-            }
-        })
-    });  
+    .on("end", async () => {
+      balances.forEach(async record => {
+        const balance = await getBalance(record.Address, rpc);
+        if (String(balance) === record.Balance) {
+          console.log(record.Address, "   OK");
+        } else {
+          console.log(
+            record.Address,
+            "   Mismatch! Expected:",
+            record.Balance,
+            "actual: ",
+            String(balance)
+          );
+        }
+      });
+    });
 }
 
 run();

--- a/scripts/migration/compareBalances.js
+++ b/scripts/migration/compareBalances.js
@@ -1,4 +1,3 @@
-const JSBI = require('jsbi');
 const ethers = require('ethers');
 const fs = require('fs');
 const csv = require('csv-parser');
@@ -17,16 +16,14 @@ async function run() {
         balances.push(row);
     })
     .on('end', async () => {
-        let balance; 
-        for(let i = 0; i < balances.length; i++) {
-            console.log('Checking ballance of', balances[i].Address);
-            balance = await getBalance(balances[i].Address, rpc);
-            if (String(balance) === balances[i].Balance) {
-                console.log('   OK');
+        balances.forEach(async (record) => {
+            const balance = await getBalance(record.Address, rpc);
+            if (String(balance) === record.Balance) {
+                console.log(record.Address, '   OK');
             } else {
-                console.log('   Mismatch! Expected:', balances[i].Balance, 'actual: ', String(balance));
+                console.log(record.Address, '   Mismatch! Expected:', record.Balance, 'actual: ', String(balance));
             }
-        }        
+        })
     });  
 }
 

--- a/scripts/migration/dispenseTokens.js
+++ b/scripts/migration/dispenseTokens.js
@@ -24,7 +24,7 @@ async function run() {
       continue;
     }    
     await sendFunds(dispenser, record.Address, record.Balance, rpc);
-    check = await checkBalance(record.Address, record.Balance, rpc);
+    check = await checkBalance(record.Address, process.env.DRY_RUN ? 0 : record.Balance, rpc);
     if (!check.result) {
       console.log(
         ` Failed! Expected: ${record.Balance}). Actual: ${check.balance}`

--- a/scripts/migration/dispenseTokens.js
+++ b/scripts/migration/dispenseTokens.js
@@ -1,42 +1,65 @@
-const JSBI = require('jsbi');
-const ethers = require('ethers');
-const fs = require('fs');
-const csv = require('csv-parser');
-const { sendFunds, getBalance } = require ('./helpers');
+const JSBI = require("jsbi");
+const ethers = require("ethers");
+const fs = require("fs");
+const csv = require("csv-parser");
+const { sendFunds, getBalance } = require("./helpers");
 
-const nodeUrl = process.argv[2] ? process.argv[2] : "https://testnet-node.leapdao.org";
+const nodeUrl = process.argv[2]
+  ? process.argv[2]
+  : "https://testnet-node.leapdao.org";
+
 const rpc = new ethers.providers.JsonRpcProvider(nodeUrl);
-const dispenser = { 
-    address: 'PUT DISPENSER ADDRESS HERE',
-    priv: '!!!NEVER COMMIT WITH MAINNET PRIVATE KEY HERE!!!' //!!!NEVER COMMIT WITH MAINNET PRIVATE KEY HERE!!!
-}
-const snapshot = './snapshot.csv';
+
+const dispenser = {
+  address: "PUT DISPENSER ADDRESS HERE",
+  priv: "!!!NEVER COMMIT WITH MAINNET PRIVATE KEY HERE!!!" //!!!NEVER COMMIT WITH MAINNET PRIVATE KEY HERE!!!
+};
+const snapshot = "./snapshot.csv";
 
 async function run() {
-    const balances = [];
-    let balance;
+  const balances = [];
+  let balance;
 
-    fs.createReadStream(snapshot)  
+  fs.createReadStream(snapshot)
     .pipe(csv())
-    .on('data', (row) => {
-        balances.push(row);
+    .on("data", row => {
+      balances.push(row);
     })
-    .on('end', async () => {
-        for(let i = 0; i < balances.length; i++) {
-            console.log('Dispensng', balances[i].Balance, 'LEAP to', balances[i].Address);
-            balance = await getBalance(balances[i].Address, rpc);
-            if (String(balance) !== '0') {
-                console.log('   Address already funded(', String(balance), '). Skipping.');
-                continue;
-            } 
-            await sendFunds(dispenser, balances[i].Address, balances[i].Balance, rpc);
-            balance = await getBalance(balances[i].Address, rpc);
-            if (String(balance) === balances[i].Balance) {
-                console.log('   Done');
-            } else {
-                console.log('   Failed! Expected balance:', balances[i].Balance, 'actual: ', String(balance));
-            }
-        }        
+    .on("end", async () => {
+      for (let i = 0; i < balances.length; i++) {
+        console.log(
+          "Dispensng",
+          balances[i].Balance,
+          "LEAP to",
+          balances[i].Address
+        );
+        balance = await getBalance(balances[i].Address, rpc);
+        if (String(balance) !== "0") {
+          console.log(
+            "   Address already funded(",
+            String(balance),
+            "). Skipping."
+          );
+          continue;
+        }
+        await sendFunds(
+          dispenser,
+          balances[i].Address,
+          balances[i].Balance,
+          rpc
+        );
+        balance = await getBalance(balances[i].Address, rpc);
+        if (String(balance) === balances[i].Balance) {
+          console.log("   Done");
+        } else {
+          console.log(
+            "   Failed! Expected balance:",
+            balances[i].Balance,
+            "actual: ",
+            String(balance)
+          );
+        }
+      }
     });
 }
 

--- a/scripts/migration/getSnapshot.js
+++ b/scripts/migration/getSnapshot.js
@@ -1,14 +1,14 @@
-const JSBI = require("jsbi");
-const ethers = require("ethers");
-const createCsvWriter = require("csv-writer").createArrayCsvWriter;
-const { getBalancesAll } = require("./helpers");
+const JSBI = require('jsbi');
+const ethers = require('ethers');
+const createCsvWriter = require('csv-writer').createArrayCsvWriter;
+const { getBalancesAll } = require('./helpers');
 
 const nodeUrl = process.argv[2]
   ? process.argv[2]
-  : "https://testnet-node.leapdao.org";
+  : 'https://testnet-node.leapdao.org';
   
 const rpc = new ethers.providers.JsonRpcProvider(nodeUrl);
-const snapshot = "./snapshot.csv";
+const snapshot = './snapshot.csv';
 
 async function run() {
   const unspentsAll = await getBalancesAll(rpc);
@@ -18,17 +18,17 @@ async function run() {
     return JSBI.add(sum, JSBI.BigInt(balance[1]));
   }, JSBI.BigInt(0));
 
-  console.log("Total value of all addresses: ", String(totalValue));
+  console.log('Total value of all addresses: ', String(totalValue));
 
-  console.log("Writing balances data to CSV file");
+  console.log('Writing balances data to CSV file');
   const csvWriter = createCsvWriter({
     path: snapshot,
-    header: ["Address", "Balance"]
+    header: ['Address', 'Balance']
   });
 
   csvWriter
     .writeRecords([...unspentsAll])
-    .then(() => console.log("The CSV file was written successfully"));
+    .then(() => console.log('The CSV file was written successfully'));
 }
 
 run();

--- a/scripts/migration/getSnapshot.js
+++ b/scripts/migration/getSnapshot.js
@@ -1,30 +1,34 @@
-const JSBI = require('jsbi');
-const ethers = require('ethers');
-const createCsvWriter = require('csv-writer').createArrayCsvWriter;
-const { getBalancesAll } = require('./helpers');
+const JSBI = require("jsbi");
+const ethers = require("ethers");
+const createCsvWriter = require("csv-writer").createArrayCsvWriter;
+const { getBalancesAll } = require("./helpers");
 
-const nodeUrl = process.argv[2] ? process.argv[2] : "https://testnet-node.leapdao.org";
+const nodeUrl = process.argv[2]
+  ? process.argv[2]
+  : "https://testnet-node.leapdao.org";
+  
 const rpc = new ethers.providers.JsonRpcProvider(nodeUrl);
-const snapshot = './snapshot.csv';
+const snapshot = "./snapshot.csv";
 
 async function run() {
-    const unspentsAll = await getBalancesAll(rpc);
-    console.log(unspentsAll);
-    
-    const totalValue = [...unspentsAll].reduce((sum, balance) => {
-        return JSBI.add(sum, JSBI.BigInt(balance[1])) }, JSBI.BigInt(0));
+  const unspentsAll = await getBalancesAll(rpc);
+  console.log(unspentsAll);
 
-    console.log("Total value of all addresses: ", String(totalValue));
+  const totalValue = [...unspentsAll].reduce((sum, balance) => {
+    return JSBI.add(sum, JSBI.BigInt(balance[1]));
+  }, JSBI.BigInt(0));
 
-    console.log('Writing balances data to CSV file');
-    const csvWriter = createCsvWriter({  
-        path: snapshot,
-        header: ['Address', 'Balance']
-    });
+  console.log("Total value of all addresses: ", String(totalValue));
 
-    csvWriter  
-        .writeRecords([...unspentsAll])
-        .then(() => console.log('The CSV file was written successfully'));
+  console.log("Writing balances data to CSV file");
+  const csvWriter = createCsvWriter({
+    path: snapshot,
+    header: ["Address", "Balance"]
+  });
+
+  csvWriter
+    .writeRecords([...unspentsAll])
+    .then(() => console.log("The CSV file was written successfully"));
 }
 
 run();

--- a/scripts/migration/getSnapshot.js
+++ b/scripts/migration/getSnapshot.js
@@ -3,11 +3,7 @@ const ethers = require('ethers');
 const createCsvWriter = require('csv-writer').createArrayCsvWriter;
 const { getBalancesAll } = require('./helpers');
 
-const nodeUrl = process.argv[2]
-  ? process.argv[2]
-  : 'https://testnet-node.leapdao.org';
-  
-const rpc = new ethers.providers.JsonRpcProvider(nodeUrl);
+const rpc = new ethers.providers.JsonRpcProvider(process.env.NODE_URL);
 const snapshot = './snapshot.csv';
 
 async function run() {

--- a/scripts/migration/helpers.js
+++ b/scripts/migration/helpers.js
@@ -1,7 +1,9 @@
 const JSBI = require('jsbi');
+const { BigInt, add } = JSBI;
 const fs = require('fs');
 const csv = require('csv-parser');
-const { Tx, helpers, Outpoint } = require('leap-core');
+const { Tx, helpers, Output, Outpoint } = require('leap-core');
+const { sendSignedTransaction } = helpers;
 
 const checkBalance = (addr, expectedBalance, rpc) =>
     getBalance(addr, rpc)
@@ -58,6 +60,47 @@ async function getBalancesAll(rpc) {
   return balances;
 }
 
+async function sendFundsBatched(from, toArr, rpc) {
+    
+  const totalOutputValue = toArr.reduce((total, to) => {
+      total = add(total, BigInt(to.value));
+      return total;
+  }, BigInt(0));
+
+  // calc inputs
+  const utxos = (await rpc.send("plasma_unspent", [from.address, 0]))
+    .map(u => ({
+      output: u.output,
+      outpoint: Outpoint.fromRaw(u.outpoint),
+    }));
+
+  if (utxos.length === 0) {
+    throw new Error('No tokens left in the dispenser wallet');
+  }
+  
+  const inputs = helpers.calcInputs(utxos, from.address, totalOutputValue, 0);
+
+  // create change output if needed
+  let outputs = helpers.calcOutputs(utxos, inputs, from.address, from.address, totalOutputValue, 0);
+  if (outputs.length > 1) { // if we have change output
+    outputs = outputs.splice(-1); // leave only change
+  } else {
+    outputs = [];
+  }
+
+  // add output for each faucet request
+  outputs = outputs.concat(toArr.map(to => new Output(to.value, to.address, 0)));
+  
+  const tx = Tx.transfer(inputs, outputs).signAll(from.priv);
+  let txHash;
+  // eslint-disable-next-line no-console
+  if (!process.env.DRY_RUN) {
+    txHash = await sendSignedTransaction(rpc, tx.hex());
+  }
+  console.log('txHash:', txHash);
+}
+  
+
 async function sendFunds(from, to, amount, rpc) {
   const utxos = (await rpc.send('plasma_unspent', [from.address])).map(u => ({
     output: u.output,
@@ -76,12 +119,10 @@ async function sendFunds(from, to, amount, rpc) {
 
   let txHash;
   // eslint-disable-next-line no-console
-  if (process.env.DRY_RUN) {
-    console.log(`'eth_sendRawTransaction', [${tx.hex()}]`);
-  } else {
+  if (!process.env.DRY_RUN) {
     txHash = await rpc.send('eth_sendRawTransaction', [tx.hex()]);
   }
   console.log('txHash:', txHash);
 }
 
-module.exports = { getBalance, getBalancesAll, sendFunds, readSnapshot, checkBalance };
+module.exports = { getBalance, getBalancesAll, sendFunds, readSnapshot, checkBalance, sendFundsBatched };

--- a/scripts/migration/helpers.js
+++ b/scripts/migration/helpers.js
@@ -1,51 +1,55 @@
-const JSBI = require('jsbi');
-const { Tx, helpers, Output, Outpoint } = require('leap-core');
+const JSBI = require("jsbi");
+const { Tx, helpers, Output, Outpoint } = require("leap-core");
 
 async function getBalance(address, rpc) {
-    const response = await rpc.send('plasma_unspent', [address]);
-    const balance = response.reduce((sum, unspent) => { 
-        return (unspent.output.color === 0) ? JSBI.add(sum, JSBI.BigInt(unspent.output.value)) : sum}, JSBI.BigInt(0));
+  const response = await rpc.send("plasma_unspent", [address]);
+  const balance = response.reduce((sum, unspent) => {
+    return unspent.output.color === 0
+      ? JSBI.add(sum, JSBI.BigInt(unspent.output.value))
+      : sum;
+  }, JSBI.BigInt(0));
 
-    return balance;
+  return balance;
 }
 
 async function getBalancesAll(rpc) {
-    const response = await rpc.send('plasma_unspent', []);
-    let balances = new Map();
-    let value;
-    let address;
-    response.forEach(unspent => {
-        if (unspent.output.color === 0) {
-            address = unspent.output.address;
-            value = JSBI.BigInt(unspent.output.value);
-            value = balances.get(address) ? JSBI.add(JSBI.BigInt(balances.get(address)), value) : value;
-            balances.set(address, String(value));
-        }        
-    });
+  const response = await rpc.send("plasma_unspent", []);
+  let balances = new Map();
+  let value;
+  let address;
+  response.forEach(unspent => {
+    if (unspent.output.color === 0) {
+      address = unspent.output.address;
+      value = JSBI.BigInt(unspent.output.value);
+      value = balances.get(address)
+        ? JSBI.add(JSBI.BigInt(balances.get(address)), value)
+        : value;
+      balances.set(address, String(value));
+    }
+  });
 
-    return balances;
+  return balances;
 }
 
 async function sendFunds(from, to, amount, rpc) {
-    const utxos = (await rpc.send("plasma_unspent", [from.address]))
-    .map(u => ({
-      output: u.output,
-      outpoint: Outpoint.fromRaw(u.outpoint),
-    }));
+  const utxos = (await rpc.send("plasma_unspent", [from.address])).map(u => ({
+    output: u.output,
+    outpoint: Outpoint.fromRaw(u.outpoint)
+  }));
 
-    if (utxos.length === 0) {
-        throw new Error("No tokens left in the dispenser wallet");
-    }
+  if (utxos.length === 0) {
+    throw new Error("No tokens left in the dispenser wallet");
+  }
 
-    const inputs = helpers.calcInputs(utxos, from.address, amount, 0);
+  const inputs = helpers.calcInputs(utxos, from.address, amount, 0);
 
-    let outputs = helpers.calcOutputs(utxos, inputs, from.address, to, amount, 0);
+  let outputs = helpers.calcOutputs(utxos, inputs, from.address, to, amount, 0);
 
-    const tx = Tx.transfer(inputs, outputs).signAll(from.priv);
+  const tx = Tx.transfer(inputs, outputs).signAll(from.priv);
 
-    // eslint-disable-next-line no-console
-    const txHash = await rpc.send("eth_sendRawTransaction", [tx.hex()]);
-    console.log('txHash:', txHash);
+  // eslint-disable-next-line no-console
+  const txHash = await rpc.send("eth_sendRawTransaction", [tx.hex()]);
+  console.log("txHash:", txHash);
 }
 
-module.exports = { getBalance, getBalancesAll, sendFunds }
+module.exports = { getBalance, getBalancesAll, sendFunds };

--- a/scripts/migration/helpers.js
+++ b/scripts/migration/helpers.js
@@ -7,7 +7,7 @@ const checkBalance = (addr, expectedBalance, rpc) =>
     getBalance(addr, rpc)
         .then(balance => ({
             addr,
-            result: String(balance) === expectedBalance,
+            result: String(balance) === String(expectedBalance),
             balance 
         }))
         .catch(e => {
@@ -74,9 +74,13 @@ async function sendFunds(from, to, amount, rpc) {
 
   const tx = Tx.transfer(inputs, outputs).signAll(from.priv);
 
+  let txHash;
   // eslint-disable-next-line no-console
-  console.log(`'eth_sendRawTransaction', [${tx.hex()}]`)
-  //const txHash = await rpc.send('eth_sendRawTransaction', [tx.hex()]);
+  if (process.env.DRY_RUN) {
+    console.log(`'eth_sendRawTransaction', [${tx.hex()}]`);
+  } else {
+    txHash = await rpc.send('eth_sendRawTransaction', [tx.hex()]);
+  }
   console.log('txHash:', txHash);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1407,6 +1407,11 @@ leap-core@0.30.1:
     jsbi-utils "^1.0.0"
     node-fetch "^2.3.0"
 
+lodash.chunk@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.chunk/-/lodash.chunk-4.2.0.tgz#66e5ce1f76ed27b4303d8c6512e8d1216e8106bc"
+  integrity sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw=
+
 lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"


### PR DESCRIPTION
Highlights:
- faster balance checks by avoiding `await` for each check. Instead bursting checks in parallel and `await` on `Promise.all`
- compatibility with other scripts (using `NODE_URL` from ENV)
- no private key placeholder in the code as it was error-prone
- allow to run `dispenseTokens` dry with `DRY_RUN` ENV var

Depends on: https://github.com/leapdao/leap-core/pull/109