### PR TITLE
feat: add registerToken script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "leap-nstDeposit": "scripts/nstDeposit.js"
   },
   "dependencies": {
+    "commander": "^2.20.0",
     "csv-parser": "^2.2.0",
     "csv-writer": "^1.2.0",
     "ethereumjs-util": "^6.1.0",

--- a/scripts/registerToken.js
+++ b/scripts/registerToken.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright (c) 2018-present, Leap DAO (leapdao.org)
+ *
+ * This source code is licensed under the Mozilla Public License Version 2.0
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable no-await-in-loop, no-console */
+
+
+/**
+ * Creates an encoded governance proposal to register token.
+ * 
+ * Restrictions:
+ * - network should be governed by MinGov
+ * 
+ * Env params:
+ * NODE_URL    - JSON RPC endpoint of the Leap node. Default to local node
+ * PRIV_KEY    - private key for ethereum account owning the network governance
+ * 
+ * Example: NODE_URL=https://testnet-node.leapdao.org node scripts/registerToken.js -a 0x06f187da6a2b0f5255e7e27aa96575987074648e -t nst
+ */
+
+const ethers = require('ethers');
+const program = require('commander');
+const { isValidAddress } = require('ethereumjs-util');
+
+const exitHandlerAbi = require('../abis/exitHandlerAbi');
+const governanceAbi = require('../abis/minGovAbi');
+const getWallet = require('./utils/wallet');
+
+async function run(tokenAddr, tokenType) {
+  const { rootWallet, nodeConfig } = await getWallet();
+  const { exitHandlerAddr } = nodeConfig;
+
+  const exitHandler = new ethers.Contract(exitHandlerAddr, exitHandlerAbi, rootWallet);
+  const governance = new ethers.Contract(await exitHandler.admin(), governanceAbi, rootWallet);
+  const govOwner = await governance.owner();
+
+  let data;
+
+  if (tokenType === 'nst') {
+    console.log(`registerNST("${tokenAddr}"`);
+    data = exitHandler.interface.functions.registerNST.encode([tokenAddr]);
+  } else {
+    console.log(`registerToken("${tokenAddr}", ${tokenType === 'nft'})`);
+    data = exitHandler.interface.functions.registerToken.encode([tokenAddr, tokenType === 'nft']);
+  }
+  console.log();
+  console.log('MinGov: ', governance.address);
+  console.log('Owner of MinGov: ', govOwner);
+  console.log();
+  console.log(`Tx to send: propose("${exitHandlerAddr}", "${data}")`);
+}
+
+
+const halt = (msg) => {
+  console.error(msg);
+  return program.outputHelp();
+}
+
+
+program
+  .option('-a, --addr <addr>', 'Token address')
+  .option('-t, --type <type>', 'Token type: ERC20, NFT, NST');
+
+program.parse(process.argv);
+
+if (!process.argv.slice(2).length) {
+  return program.outputHelp();
+}
+
+const { addr, type } = program;
+
+if (!addr) return halt('Missing token address');
+
+if (!isValidAddress(addr)) return halt('Address is not valid Ethereum address'); 
+if (!type) return halt('Missing token type: ERC20, NFT or NST'); 
+if (['erc20', 'nst', 'nft'].indexOf(type.toLowerCase()) < 0) return halt('Invalid token type: ERC20, NFT or NST'); 
+
+run(addr, type.toLowerCase());

--- a/scripts/utils/wallet.js
+++ b/scripts/utils/wallet.js
@@ -2,10 +2,9 @@ const ethers = require('ethers');
 const getRootNetworkProvider = require('./getRootNetworkProvider');
 
 module.exports = async (params = {}) => {
-  console.log(params);
   const nodeUrl = params.nodeUrl || process.env.NODE_URL || 'http://localhost:8645';
   const privKey = params.privKey || process.env.PRIV_KEY || '0x0000000000000000000ef2ef02e9911337f8758e93c801b619e5d178094486cc';
-  console.log(nodeUrl, privKey);
+  console.log('Leap node: ', nodeUrl);
   const plasmaWallet = new ethers.Wallet(
     privKey, 
     new ethers.providers.JsonRpcProvider(nodeUrl),

--- a/yarn.lock
+++ b/yarn.lock
@@ -332,6 +332,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+
 commander@^2.8.1:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1379,10 +1379,10 @@ keccakjs@^0.2.1:
     browserify-sha3 "^0.0.4"
     sha3 "^1.2.2"
 
-leap-core@0.31.1:
-  version "0.31.1"
-  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.31.1.tgz#570c1a5b5c36aaed1725ded70a9f0e7abcc128b9"
-  integrity sha512-jkeWChYqiSmnPG7tFOjBarGE5zsZgvxTyq6NTqotQNNyCnrjrPVcl5nn31cmiG9WTdSBC/n83M6tUpVeakmW0A==
+leap-core@0.32.0:
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.32.0.tgz#63a1d30d72798755c7aaf59173ed6d4d4db8336d"
+  integrity sha512-QG/I4lDaKVddpLhFu77HcP6ijRVhrGTi5ne9YTrsxYOHVtSgGyoUXV3U2WV89c9KOTVtG6uhspAVXw/AYRzJVg==
   dependencies:
     "@types/web3" "^1.0.18"
     ethereumjs-util "6.0.0"


### PR DESCRIPTION
Requires #17 

```
Usage: registerToken [options]

Options:
  -a, --addr <addr>  Token address
  -t, --type <type>  Token type: ERC20, NFT, NST
  -h, --help         output usage information
```

Usage example:

```
> NODE_URL=https://testnet-node.leapdao.org node scripts/registerToken.js -a 0x06f187da6a2b0f5255e7e27aa96575987074648e -t nst
Leap node:  https://testnet-node.leapdao.org
registerNST("0x06f187da6a2b0f5255e7e27aa96575987074648e"

MinGov:  0xf3B4111c6CdAf82062A6e5EB65e12B76f2E881E8
Owner of MinGov:  0x03CAa70D57c9E98c0CeAf1EF95f9C9459B89f1Bf

Tx to send: propose("0x26a937302cc6A0A7334B210de06136C8C61BA885", "0x23b1896a00000000000000000000000006f187da6a2b0f5255e7e27aa96575987074648e")
```