### PR TITLE
feat: add epoch length option to setValidator.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ethers": "^4.0.27",
     "jsbi": "^2.0.5",
     "leap-core": "0.35.0",
-    "leap-provider": "^1.0.0",
+    "leap-provider": "^1.2.0",
     "lodash.chunk": "^4.2.0",
     "truffle-hdwallet-provider": "^1.0.6",
     "web3": "1.0.0-beta.37"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,10 +1394,10 @@ leap-core@0.35.0:
     jsbi-utils "^1.0.0"
     node-fetch "^2.3.0"
 
-leap-provider@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/leap-provider/-/leap-provider-1.0.0.tgz#0798783b1c9fc8b5892fb183da857957d1cf9231"
-  integrity sha512-iawd6QLqJnszXMW+N0D/1wqS+LSctqa5iB8IZDtIP5nc5NTPy5Iie7m24dklQdeUut+WMdEExgWKVEmjWO8FZA==
+leap-provider@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/leap-provider/-/leap-provider-1.2.0.tgz#bf1ffdf43e47cc7d97e4bd00c2a415da6842a44f"
+  integrity sha512-bDT4QmzeE71S4/a6F+UBHf8DYCNfeNRQu6UQTOiEgVWA8HLt+eEr5UGcarXNSNBYsHYJsNtup0Nhjx0oTaNeTA==
 
 lodash.chunk@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
This enabled setValidator script to set epoch length to an arbitrary value (allowed by the networtk ofc).

Useful example for this is:
1. run leap sandbox in a rootOnly mode. Plasma contract will be deployed with default epoch length of 2.
2. you want to run just one validator, so you can use this script with additional EPOCH_LENGTH=1 env var to set epoch length to the correct value