### PR TITLE
feat: mint heartbeat token in setValidator script

### DIFF
--- a/abis/heartbeatToken.js
+++ b/abis/heartbeatToken.js
@@ -1,0 +1,484 @@
+module.exports = [
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getApproved",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenOfOwnerByIndex",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenByIndex",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ownerOf",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "addMinter",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceMinter",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "isMinter",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenURI",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "MinterAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "MinterRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "approved",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "name": "_slotId",
+        "type": "uint8"
+      }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "burn",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+];

--- a/abis/index.js
+++ b/abis/index.js
@@ -1,7 +1,16 @@
-const bridgeAbi = require('./bridgeAbi');
-const erc20Abi = require('./erc20Abi');
-const operatorAbi = require('./operatorAbi');
-const exitHandlerAbi = require('./exitHandlerAbi');
-const minGovAbi = require('./minGovAbi');
+const bridgeAbi = require("./bridgeAbi");
+const erc20Abi = require("./erc20Abi");
+const operatorAbi = require("./operatorAbi");
+const exitHandlerAbi = require("./exitHandlerAbi");
+const minGovAbi = require("./minGovAbi");
+const heartbeatTokenAbi = require("./heartbeatToken");
 
-module.exports = { bridgeAbi, erc20Abi, operatorAbi, bridgeAbi, exitHandlerAbi, minGovAbi };
+module.exports = {
+  bridgeAbi,
+  erc20Abi,
+  operatorAbi,
+  bridgeAbi,
+  exitHandlerAbi,
+  minGovAbi,
+  heartbeatTokenAbi
+};

--- a/abis/operatorAbi.js
+++ b/abis/operatorAbi.js
@@ -2,7 +2,35 @@ module.exports = [
   {
     constant: true,
     inputs: [],
+    name: "heartbeatColor",
+    outputs: [
+      {
+        name: "",
+        type: "uint16"
+      }
+    ],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
     name: "casChallengeDuration",
+    outputs: [
+      {
+        name: "",
+        type: "uint256"
+      }
+    ],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "takenSlots",
     outputs: [
       {
         name: "",
@@ -71,6 +99,20 @@ module.exports = [
   {
     constant: true,
     inputs: [],
+    name: "minimumPulse",
+    outputs: [
+      {
+        name: "",
+        type: "uint256"
+      }
+    ],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [],
     name: "lastCompleteEpoch",
     outputs: [
       {
@@ -118,6 +160,33 @@ module.exports = [
       {
         name: "",
         type: "uint256"
+      }
+    ],
+    payable: false,
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: "",
+        type: "address"
+      }
+    ],
+    name: "beatChallenges",
+    outputs: [
+      {
+        name: "challenger",
+        type: "address"
+      },
+      {
+        name: "openTime",
+        type: "uint256"
+      },
+      {
+        name: "openPeriodHash",
+        type: "bytes32"
       }
     ],
     payable: false,
@@ -375,6 +444,24 @@ module.exports = [
     constant: false,
     inputs: [
       {
+        name: "_minimumPulse",
+        type: "uint256"
+      },
+      {
+        name: "_heartbeatColor",
+        type: "uint16"
+      }
+    ],
+    name: "setHeartbeatParams",
+    outputs: [],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      {
         name: "_epochLength",
         type: "uint256"
       }
@@ -591,6 +678,65 @@ module.exports = [
       }
     ],
     name: "timeoutCas",
+    outputs: [],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: "rebuildTakenSlots",
+    outputs: [],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: "_slotId",
+        type: "uint256"
+      }
+    ],
+    name: "challengeBeat",
+    outputs: [],
+    payable: true,
+    stateMutability: "payable",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: "_inclusionProof",
+        type: "bytes32[]"
+      },
+      {
+        name: "_walkProof",
+        type: "bytes32[]"
+      },
+      {
+        name: "_slotId",
+        type: "uint256"
+      }
+    ],
+    name: "respondBeat",
+    outputs: [],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: "_slotId",
+        type: "uint256"
+      }
+    ],
+    name: "timeoutBeat",
     outputs: [],
     payable: false,
     stateMutability: "nonpayable",


### PR DESCRIPTION
### What does this PR do?

This PR changes `setValidator` script in two ways:
- script checks if there is a heartbeat token set up on the current network. If it is, it will mint and deposit a new heartbeat token for a validator as well as setting a slot
- script can now be `require`ed by other scripts (e.g. leap-sandbox) and called like:
  ```js
  await setValidator(slotId, validatorTendermintAddress, validatorEthAddress, optionalEpochLengthToSet, { plasmaWallet, rootWallet, nodeConfig }
   ```
   where 
   - `plasmaWallet` is a ethers.js Wallet for plasma provider (e.g. as returned by [/scripts/utils/wallet](https://github.com/leapdao/leap-guardian/blob/master/scripts/utils/wallet.js))
   - `rootWallet` is an ethers.js Wallet instance for root chain provider (e.g. as returned by [/scripts/utils/wallet](https://github.com/leapdao/leap-guardian/blob/master/scripts/utils/wallet.js))
   - `nodeConfig` is a [NodeConfig](https://github.com/leapdao/leap-core/blob/master/index.d.ts#L289) object (the only used attributes so far are exitHandlerAddr and operatorAddr)

### Recommendations for testing

With heartbeat:
1. Set up a local leap network
2. Deploy and register heartbeat token. Can be any NFT, but you can use leap-sandbox to do that for you (see updated version)
3. call `SLOT=0 NODE_URL=http://localhost:8645 node scripts/setValidator`. It should set the slot, fund validator and also mint and deposit heartbeat token.

Without heartbeat:
1. Set up a local leap network without a heartbeat token (e.g. leap-sandbox with `--noHeartbeat` flag)
2. call `SLOT=0 NODE_URL=http://localhost:8645 node scripts/setValidator`. It should only set the slot and fund validator

### Links to relevant issues or information

https://github.com/leapdao/leap-contracts/pull/276
https://github.com/leapdao/leap-sandbox/pull/81
